### PR TITLE
Split ansible tasks in files

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1,0 +1,101 @@
+---
+# list of tasks to be always executed
+# For this to work, previously these packages
+# must have been installed:
+#    kolibri-server
+#    dnsmasq
+#    hostapd
+
+
+- name: Insert/update dhcpcd.conf settings block
+  become: yes
+  blockinfile:
+    path: /etc/dhcpcd.conf
+    block: |
+      interface wlan0
+          static ip_address=10.10.10.10/24
+          nohook resolv.conf, wpa_supplicant
+
+- name: Copy in dnsmasq configuration
+  become: yes
+  copy:
+    src: files/dnsmasq_hotspot.conf
+    dest: /etc/dnsmasq.d/hotspot.conf
+
+- name: Set up custom hostapd conf file for 2.4GHz.
+  become: yes
+  copy:
+    src: files/hostapd.conf
+    dest: /etc/hostapd/hostapd.conf
+
+- name: Set up custom hostapd conf file for 5GHz.
+  become: yes
+  copy:
+    src: files/hostapd_5ghz.conf
+    dest: /etc/hostapd/hostapd_5ghz.conf
+
+- name: Insert/update hostapd settings block
+  become: yes
+  blockinfile:
+    path: /etc/default/hostapd
+    block: |
+      DAEMON_CONF="/etc/hostapd/hostapd.conf"
+
+- name: Ensure dnsmasq doesn't interfere with local DNS
+  become: yes
+  blockinfile:
+    path: /etc/default/dnsmasq
+    block: |
+      DNSMASQ_EXCEPT=lo
+
+- name: Remove the default nginx config file (so it won't conflict).
+  become: yes
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+
+- name: Copy in usb-mount.sh (script for automounting USB)
+  become: yes
+  copy:
+    src: files/usb-mount.sh
+    dest: /usr/local/bin/usb-mount.sh
+    mode: '755'
+
+- name: Copy in systemd unit file for USB automount/unmount
+  become: yes
+  copy:
+    src: files/usb-mount@.service
+    dest: /etc/systemd/system/usb-mount@.service
+
+- name: Create udev rule to start/stop usb-mount@.service on hotplug/unplug
+  become: yes
+  blockinfile:
+    path: /etc/udev/rules.d/99-local.rules
+    create: yes
+    block: |
+      KERNEL=="sd[a-z]*[0-9]", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/bin/systemctl start usb-mount@%k.service"
+      KERNEL=="sd[a-z]*[0-9]", SUBSYSTEMS=="usb", ACTION=="remove", RUN+="/bin/systemctl stop usb-mount@%k.service"
+
+- name: Ensure services are unmasked, enabled, and restarted.
+  become: yes
+  systemd:
+    name: "{{ item }}"
+    enabled: yes
+    masked: no
+    state: restarted
+    daemon_reload: yes
+  loop:
+    - dhcpcd
+    - hostapd
+    - dnsmasq
+    - nginx
+    - kolibri-server
+
+- name: Reload the udev rules
+  become: yes
+  shell:
+    udevadm control --reload-rules
+
+
+# TODO (stretch goal): get it working in both AP and client wifi modes at the same time!
+# https://blog.thewalr.us/2017/09/26/raspberry-pi-zero-w-simultaneous-ap-and-managed-mode-wifi/

--- a/install.yml
+++ b/install.yml
@@ -1,150 +1,18 @@
----
-- hosts: all
+
+- hosts: localhost
 
   tasks:
+  - name: Gather the Debian package facts
+    package_facts:
+      manager: apt
 
-  - name: Create the directory where Kolibri content will live.
-    become: yes
-    file:
-      path: /KOLIBRI_DATA/content
-      state: directory
-      owner: pi
+  - name: Apply tasks to build the whole RPi config
+    import_tasks: online.yml
+    when: "'kolibri-server' not in ansible_facts.packages"
 
-  - name: Create the directory where Kolibri data will live.
-    file:
-      path: /home/pi/.kolibri
-      state: directory
+  - name: Apply tasks to be executed if kolibri-server is installed
+    import_tasks: offline.yml
+    when: "'kolibri-server' in ansible_facts.packages"
 
-  - name: Copy in the skeleton Kolibri options.ini file.
-    copy:
-      src: files/options.ini
-      dest: /home/pi/.kolibri/options.ini
-
-  - name: Add the PPA signing key
-    become: yes
-    apt_key:
-      id: DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
-      keyserver: keyserver.ubuntu.com
-
-  - name: Add the Kolibri PPA
-    become: yes
-    apt_repository:
-      repo: deb http://ppa.launchpad.net/learningequality/kolibri/ubuntu xenial main
-      state: present
-      filename: learningequality-ubuntu-kolibri-xenial
-
-  - name: Update repository cache, and upgrade everything
-    become: yes
-    apt:
-      update_cache: yes
-      upgrade: yes
-
-  - name: Install necessary packages
-    become: yes
-    apt:
-      name: "{{ packages }}"
-    vars:
-      packages:
-      - kolibri
-      - dnsmasq
-      - hostapd
-      - nginx
-
-  - name: Insert/update dhcpcd.conf settings block
-    become: yes
-    blockinfile:
-      path: /etc/dhcpcd.conf
-      block: |
-        interface wlan0
-            static ip_address=10.10.10.10/24
-            nohook resolv.conf, wpa_supplicant
-
-  - name: Copy in dnsmasq configuration
-    become: yes
-    copy:
-      src: files/dnsmasq_hotspot.conf
-      dest: /etc/dnsmasq.d/hotspot.conf
-
-  - name: Set up custom hostapd conf file for 2.4GHz.
-    become: yes
-    copy:
-      src: files/hostapd.conf
-      dest: /etc/hostapd/hostapd.conf
-
-  - name: Set up custom hostapd conf file for 5GHz.
-    become: yes
-    copy:
-      src: files/hostapd_5ghz.conf
-      dest: /etc/hostapd/hostapd_5ghz.conf
-
-  - name: Insert/update hostapd settings block
-    become: yes
-    blockinfile:
-      path: /etc/default/hostapd
-      block: |
-        DAEMON_CONF="/etc/hostapd/hostapd.conf"
-
-  - name: Ensure dnsmasq doesn't interfere with local DNS
-    become: yes
-    blockinfile:
-      path: /etc/default/dnsmasq
-      block: |
-        DNSMASQ_EXCEPT=lo
-
-  - name: Remove the default nginx config file (so it won't conflict).
-    become: yes
-    file:
-      path: /etc/nginx/sites-enabled/default
-      state: absent
-
-  - name: Set up custom nginx conf file.
-    become: yes
-    copy:
-      src: files/nginx_kolibri_conf
-      dest: /etc/nginx/sites-enabled/kolibri
-
-  - name: Copy in usb-mount.sh (script for automounting USB)
-    become: yes
-    copy:
-      src: files/usb-mount.sh
-      dest: /usr/local/bin/usb-mount.sh
-      mode: '755'
-
-  - name: Copy in systemd unit file for USB automount/unmount
-    become: yes
-    copy:
-      src: files/usb-mount@.service
-      dest: /etc/systemd/system/usb-mount@.service
-
-  - name: Create udev rule to start/stop usb-mount@.service on hotplug/unplug
-    become: yes
-    blockinfile:
-      path: /etc/udev/rules.d/99-local.rules
-      create: yes
-      block: |
-        KERNEL=="sd[a-z]*[0-9]", SUBSYSTEMS=="usb", ACTION=="add", RUN+="/bin/systemctl start usb-mount@%k.service"
-        KERNEL=="sd[a-z]*[0-9]", SUBSYSTEMS=="usb", ACTION=="remove", RUN+="/bin/systemctl stop usb-mount@%k.service"
-
-  - name: Ensure services are unmasked, enabled, and restarted.
-    become: yes
-    systemd:
-      name: "{{ item }}"
-      enabled: yes
-      masked: no
-      state: restarted
-      daemon_reload: yes
-    loop:
-      - dhcpcd
-      - hostapd
-      - dnsmasq
-      - nginx
-      - kolibri
-
-  - name: Reload the udev rules
-    become: yes
-    shell:
-      udevadm control --reload-rules
-
-
-# TODO (stretch goal): get it working in both AP and client wifi modes at the same time!
-# https://blog.thewalr.us/2017/09/26/raspberry-pi-zero-w-simultaneous-ap-and-managed-mode-wifi/
+  - name: Include common tasks
+    import_tasks: common.yml

--- a/offline.yml
+++ b/offline.yml
@@ -1,2 +1,12 @@
 ---
 # lists of tasks to be executed if kolibri-server is already installed
+
+- name: Remove file lock file left by package installation
+  file:
+    path: /tmp/kolibri_uwsgi.sock
+    state: absent
+
+- name: Remove directory lock dir left by package installation
+  file:
+    path: /var/run/kolibri-server
+    state: absent

--- a/offline.yml
+++ b/offline.yml
@@ -1,0 +1,2 @@
+---
+# lists of tasks to be executed if kolibri-server is already installed

--- a/online.yml
+++ b/online.yml
@@ -1,0 +1,69 @@
+---
+
+- name: Create the directory where Kolibri content will live.
+  become: yes
+  file:
+    path: /KOLIBRI_DATA/content
+    state: directory
+    owner: pi
+
+- name: Create the directory where Kolibri data will live.
+  file:
+    path: /home/pi/.kolibri
+    state: directory
+
+- name: Copy in the skeleton Kolibri options.ini file.
+  copy:
+    src: files/options.ini
+    dest: /home/pi/.kolibri/options.ini
+
+- name: Add the PPA signing key
+  become: yes
+  apt_key:
+    id: DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+    keyserver: keyserver.ubuntu.com
+
+- name: Add the Kolibri PPA
+  become: yes
+  apt_repository:
+    repo: deb http://ppa.launchpad.net/learningequality/kolibri/ubuntu bionic main
+    state: present
+    filename: learningequality-ubuntu-kolibri-bionic.list
+
+- name: Update repository cache, and upgrade everything
+  become: yes
+  apt:
+    update_cache: yes
+    upgrade: yes
+
+- name: Do not init kolibri daemon on boot
+  debconf:
+    name: kolibri
+    question: kolibri/init
+    value: false
+    vtype: boolean
+
+- name: Kolibri to run under user pi
+  debconf:
+    name: kolibri
+    question: kolibri/user
+    value: pi
+    vtype: string
+
+- name: Kolibri will run on port 80
+  debconf:
+    name: kolibri-server
+    question: kolibri-server/port
+    value: '80'
+    vtype: select
+
+- name: Install necessary packages
+  become: yes
+  apt:
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - kolibri-server
+    - dnsmasq
+    - hostapd
+


### PR DESCRIPTION
This PR:
* Replaces kolibri by kolibri-server, using nginx configuration with uwsgi + same caching it was in this repository
* Splits the ansible tasks:
  * task that need to be online, i.e: install packages
  * task that need to be offline, i.e: packages have been previously installed
  * common task both to online & offline methods